### PR TITLE
fix: fix missing support for hash ignored req body keys

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -183,7 +183,7 @@ Below are not default values! If you are unsure of what each option does, please
 
   AimMiddleware(app, {
     ignoredPaths: [],
-    hashIgnoredReqBodyKeys: ['customerId', 'time'],
+    hashIgnoredReqBodyKeys: ['customerId', 'time', 'customer.name', 'customer.type'],
     hashIgnoredReqQueryKeys: ['perpage'],
     hashIgnoredReqPathPatterns: [],
     rewriteMockPathName: (requestPath: string) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vodafoneuk/aim-mocking",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Api Interceptor Middleware - localized cache lib and middleware for dalmatian and other api calls",
   "author": "Radoslaw Swiat",
   "license": "MIT",

--- a/packages/core/src/modules/cache/helpers/getFilteredReq/utils/filterReqBodyKeys/filterReqBodyKeys.ts
+++ b/packages/core/src/modules/cache/helpers/getFilteredReq/utils/filterReqBodyKeys/filterReqBodyKeys.ts
@@ -1,5 +1,7 @@
 import logger from '@vodafoneuk/aim-mocking-logger'
 import isEmpty from 'lodash/isEmpty.js'
+import get from 'lodash/get.js'
+import unset from 'lodash/unset.js'
 
 import configController from '@modules/configController'
 
@@ -13,9 +15,10 @@ export default function filterReqBodyKeys(req: FilteredRequest): FilteredRequest
   if (isEmpty(req.body)) return req
   // iterate every body data key
   for (const ignoredKey of hashIgnoredReqBodyKeys) {
-    if (typeof req.body[ignoredKey] !== 'undefined') {
+    // Lodash 'get' adds support for nested config keys eg `"customer.data.name"`
+    if (typeof get(req.body, ignoredKey) !== 'undefined') {
       logger.debug('cache').yarn.whisper(`delete body key: ${ignoredKey}`)
-      delete req.body[ignoredKey]
+      unset(req.body, ignoredKey)
     }
   }
   return req

--- a/packages/core/tests/__mockapi__/customer/GET/api-test-1-010e177e.json
+++ b/packages/core/tests/__mockapi__/customer/GET/api-test-1-010e177e.json
@@ -1,0 +1,10 @@
+{
+  "__cacheMeta": {
+    "filePath": "/Users/radoslaw.swiat/Projects/aim-mocking/packages/core/tests/__mockapi__/customer/GET/api-test-1-010e177e.json",
+    "date": "20/09/2023 10:22:17",
+    "hash": {
+      "body": "{\"customer\":{}}",
+      "query": "{}"
+    }
+  }
+}

--- a/packages/core/tests/__mockapi__/customer/GET/api-test-1-cc58677d.json
+++ b/packages/core/tests/__mockapi__/customer/GET/api-test-1-cc58677d.json
@@ -1,0 +1,10 @@
+{
+  "__cacheMeta": {
+    "filePath": "/Users/radoslaw.swiat/Projects/aim-mocking/packages/core/tests/__mockapi__/customer/GET/api-test-1-cc58677d.json",
+    "date": "20/09/2023 10:22:17",
+    "hash": {
+      "body": "{\"customer\":{\"test\":1}}",
+      "query": "{}"
+    }
+  }
+}

--- a/packages/core/tests/hashIgnoredReqBodyKeys/aim.config.ts
+++ b/packages/core/tests/hashIgnoredReqBodyKeys/aim.config.ts
@@ -1,0 +1,16 @@
+import type { AimConfig } from '../../src/types/config.types'
+
+const config: Partial<AimConfig> = {
+  hashIgnoredReqPathPatterns: ['/api/ignored-url/*', '/api/ignored-url/*/id', '/api/ignored-url/*/id/*/id'],
+  hashIgnoredReqBodyKeys: ['id', 'customer.name', 'customer.type'],
+  hashIgnoredReqQueryKeys: [],
+  proxy: {
+    '/api': {
+      target: 'http://localhost:8090',
+      secure: false,
+      changeOrigin: true,
+    },
+  },
+}
+
+export default config

--- a/packages/core/tests/hashIgnoredReqBodyKeys/hashIgnoredReqBodyKeys.spec.ts
+++ b/packages/core/tests/hashIgnoredReqBodyKeys/hashIgnoredReqBodyKeys.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// @ts-nocheck
+/** *************************************************************************** */
+/** Import - test utilities                                                     */
+/** --------------------------------------------------------------------------- */
+/** Local utilities to help prepare and run tests                               */
+/** *************************************************************************** */
+import * as loggerChecker from '../../testsUtils/loggerChecker/loggerChecker'
+import testsConfig from '../../testsUtils/config/config'
+import axiosAimConfigClient from '../../testsUtils/axiosAimConfigClient'
+import mockedServiceServer from '../../testsUtils/mockedServiceServer'
+import * as mockedServiceServerCtrl from '../../testsUtils/mockedServiceServerController'
+import axiosApiClient from '../../testsUtils/axiosApiClient'
+import wait from '../../testsUtils/wait'
+import createMock from '../../testsUtils/createMock'
+/** *************************************************************************** */
+/** Import - test configs                                                       */
+/** --------------------------------------------------------------------------- */
+/** Local utilities to help prepare and run tests                               */
+/** *************************************************************************** */
+import aimConfig from './aim.config'
+/** *************************************************************************** */
+/** Prepare test                                                                */
+/** --------------------------------------------------------------------------- */
+/** Local utilities to help prepare and run tests                               */
+/** *************************************************************************** */
+// Setup server with given aim config
+const server = mockedServiceServer(aimConfig)
+mockedServiceServerCtrl.clean()
+mockedServiceServerCtrl.bootstrap(server, testsConfig.cacheOutputDir)
+/** *************************************************************************** */
+/** Test content                                                                */
+/** --------------------------------------------------------------------------- */
+/** Local utilities to help prepare and run tests                               */
+/** *************************************************************************** */
+it('prepare', async () => {
+  await axiosAimConfigClient.initSession()
+  await axiosAimConfigClient.post('enableRecording', { enabled: false })
+  await axiosAimConfigClient.post('enableMocking', { enabled: true })
+  await axiosAimConfigClient.post('setScenario', { scenario: 'customer' })
+})
+
+it('Should support nested hash ignored req body keys', async () => {
+  server.mode = 200
+  // Make call
+  createMock('customer', 'GET', 'api-test-1-010e177e', {})
+  createMock('customer', 'GET', 'api-test-1-cc58677d', {})
+  await axiosApiClient({ reqUrl: 'api/test/1', data: { id: 1, customer: { name: 'John', type: 'test' } } })
+  await axiosApiClient({ reqUrl: 'api/test/1', data: { id: 1, customer: { name: 'Test', type: 'admin' } } })
+  await axiosApiClient({ reqUrl: 'api/test/1', data: { id: 1, customer: { name: 'Test', type: 'admin', test: 1 } } })
+  await wait(500)
+  // Check app flow
+  expect(loggerChecker.exists('Returned mocked file')).toBe(3)
+  expect(loggerChecker.exists('tests/__mockapi__/customer/GET/api-test-1-010e177e.json')).toBe(8)
+  expect(loggerChecker.exists('tests/__mockapi__/customer/GET/api-test-1-cc58677d.json')).toBe(4)
+  expect(loggerChecker.exists('The mock file not found')).toBe(0)
+}, 10000)
+
+mockedServiceServerCtrl.teardown(server)

--- a/packages/core/testsUtils/loggerChecker/loggerChecker.ts
+++ b/packages/core/testsUtils/loggerChecker/loggerChecker.ts
@@ -3,7 +3,9 @@ import stripAnsi from 'strip-ansi'
 
 export function exists(str) {
   return global.logger.filter((log) => {
-    console.log(`LOGS -> ${stripAnsi(log)}`)
+    // If you are having troubles with setting up your tests due to terminal colours,
+    // You can enable below extra log to get rid of it and be able to copy/paste directly into your tests
+    // console.log(`LOGS -> ${stripAnsi(log)}`)
     return stripAnsi(log).includes(str)
   }).length
 }


### PR DESCRIPTION
Add support for nested hash ignored req body keys eg:

```
  hashIgnoredReqBodyKeys: [
    'business.category',
    'business.type',
  ],
```