### PR TITLE
fix: missing dash in logging

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vodafoneuk/aim-mocking-logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Api Interceptor Middleware - localized cache lib and middleware for dalmatian and other api calls",
   "author": "Radoslaw Swiat",
   "license": "MIT",

--- a/packages/logger/src/utils/string-fill.ts
+++ b/packages/logger/src/utils/string-fill.ts
@@ -47,8 +47,8 @@ export function postStringFill(string) {
         .split(EOL)
         .map((line) => {
           const strippedLine = ansiStrip(line)
-          while (line.match('-') && strippedLine.length > config.systemCfg.consoleLineLength) {
-            line = line.replace('-', '')
+          while (line.match('--') && strippedLine.length > config.systemCfg.consoleLineLength) {
+            line = line.replace('--', '')
           }
           return line
         })


### PR DESCRIPTION
When using yarn.success all dashes are replaced with empty string - which is causing issues when logging file paths including dashes.

This PR ensures only double dashes are removed.